### PR TITLE
Document flexible setfrequency hours

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 - `/nextterm` — Manually post the next brevity term
 - `/define <term>` — Look up a term's definition without marking it as used
 - `/reloadterms` — Refresh the term list from Wikipedia
-- `/setfrequency <1-24>` — Set posting frequency per server (in hours)
+- `/setfrequency <hours>` — Set posting frequency per server in hours (any positive number, default 24 if not set)
 - `/enableposting` — Enable automatic daily posting of brevity terms in the current channel.
 - `/disableposting` — Disable automatic daily posting of brevity terms in the current channel.
 


### PR DESCRIPTION
## Summary
- clarify that `/setfrequency` accepts any positive number of hours
- note that 24 hours is the default frequency

## Testing
- `python -m py_compile brevitybot.py`

------
https://chatgpt.com/codex/tasks/task_e_6843122452148327a238564e6b531327