### PR TITLE
Fix .env loading for logging

### DIFF
--- a/brevitybot.py
+++ b/brevitybot.py
@@ -14,6 +14,9 @@ from urllib.parse import urlparse
 import time
 import sys
 
+# Load environment variables from a .env file before anything else
+load_dotenv()
+
 # -------------------------------
 # LOGGING
 # -------------------------------
@@ -83,7 +86,8 @@ for logger_name in (None, "discord", "brevitybot", "discord.client"):
 # -------------------------------
 # ENVIRONMENT VARIABLES
 # -------------------------------
-load_dotenv()
+# load_dotenv() was called at import time to ensure LOG_LEVEL and other
+# settings are available before configuration
 
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 FLICKR_API_KEY = os.getenv("FLICKR_API_KEY")


### PR DESCRIPTION
## Summary
- load `.env` at module import before reading LOG_LEVEL
- document that environment vars are already loaded

## Testing
- `python -m py_compile brevitybot.py`
- *(failed to run tests requiring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6843123bb2f08327906240a41b4a5174