### PR TITLE
feat: /quizstop + /quizpurge for public-quiz moderation/recovery

### DIFF
--- a/brevitybot.py
+++ b/brevitybot.py
@@ -1499,6 +1499,121 @@ async def quiz(
     except Exception:
         logger.exception("Failed to set user cooldown for user=%s", interaction.user.id)
     asyncio.create_task(close_and_summarize(quiz_id))
+
+
+@tree.command(name="quizstop", description="Cancel the current public quiz in this server.")
+@app_commands.guild_only()
+@app_commands.default_permissions(manage_messages=True)
+async def quizstop(interaction: discord.Interaction):
+    """Cancel an in-flight public quiz: disable the buttons on each question
+    message, drop all per-quiz Redis state, and post a channel message
+    announcing the cancellation. The pre-scheduled close_and_summarize task
+    will find missing meta on wake-up and skip silently — no orphaned summary.
+    """
+    try:
+        await interaction.response.defer(ephemeral=True)
+    except discord.NotFound:
+        return
+
+    guild_id = interaction.guild.id
+    active_key = f"{ACTIVE_QUIZ_KEY_PREFIX}{guild_id}"
+    quiz_id = await r.get(active_key)
+    if not quiz_id:
+        await interaction.followup.send("No active public quiz in this server.", ephemeral=True)
+        return
+
+    meta_raw = await r.get(f"quiz:{quiz_id}:meta")
+    if not meta_raw:
+        # Lock present but meta is gone (already cleaned up by deadline). Just
+        # drop the lock so a new quiz can start.
+        await r.delete(active_key)
+        await interaction.followup.send(
+            "Cleared a stale active-quiz lock (the quiz had already finished or expired).",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        meta: QuizMeta = json.loads(meta_raw)
+    except Exception:
+        logger.exception("quizstop: bad meta JSON for quiz_id=%s", quiz_id)
+        await interaction.followup.send("Couldn't parse quiz state. See logs.", ephemeral=True)
+        return
+
+    n = len(meta["correct_indices"])
+    await _cleanup_quiz_keys(quiz_id, n, guild_id=guild_id)
+
+    # Strip the buttons off each question message so further clicks can't be
+    # confused with a live quiz. Best-effort — a fetch failure shouldn't block
+    # the cancel.
+    channel = interaction.channel
+    disabled = 0
+    for msg_id in meta.get("message_ids", []):
+        try:
+            msg = await channel.fetch_message(msg_id)
+            await msg.edit(view=None)
+            disabled += 1
+        except Exception:
+            logger.debug("quizstop: couldn't strip view from msg %s", msg_id)
+
+    logger.info(
+        "Quiz cancelled",
+        extra={"quiz_id": quiz_id, "guild_id": guild_id, "by_user_id": interaction.user.id, "disabled_views": disabled},
+    )
+
+    try:
+        await channel.send(f"**Quiz cancelled** by {interaction.user.mention}. No summary will be posted.")
+    except Exception:
+        logger.exception("Failed to post cancellation message")
+
+    await interaction.followup.send(
+        f"Cancelled the active quiz ({n} question{'s' if n != 1 else ''}; "
+        f"disabled buttons on {disabled} message{'s' if disabled != 1 else ''}).",
+        ephemeral=True,
+    )
+
+
+@tree.command(name="quizpurge", description="Force-clear a stuck active-quiz lock (admin recovery).")
+@app_commands.guild_only()
+@app_commands.default_permissions(manage_guild=True)
+async def quizpurge(interaction: discord.Interaction):
+    """Recovery command for the rare case where the active-quiz lock is held
+    but no quiz meta exists (e.g. a crash between SET NX and meta-persist, or
+    a manual Redis state deletion). Refuses to run if meta still exists — use
+    /quizstop for healthy quizzes.
+    """
+    try:
+        await interaction.response.defer(ephemeral=True)
+    except discord.NotFound:
+        return
+
+    guild_id = interaction.guild.id
+    active_key = f"{ACTIVE_QUIZ_KEY_PREFIX}{guild_id}"
+    quiz_id = await r.get(active_key)
+    if not quiz_id:
+        await interaction.followup.send("No active-quiz lock to clear.", ephemeral=True)
+        return
+
+    meta_exists = await r.exists(f"quiz:{quiz_id}:meta")
+    if meta_exists:
+        await interaction.followup.send(
+            f"There's a healthy active quiz (id `{quiz_id}`). Use **/quizstop** to cancel it "
+            "instead of /quizpurge.",
+            ephemeral=True,
+        )
+        return
+
+    await r.delete(active_key)
+    logger.info(
+        "Stale active-quiz lock cleared",
+        extra={"quiz_id": quiz_id, "guild_id": guild_id, "by_user_id": interaction.user.id},
+    )
+    await interaction.followup.send(
+        f"Cleared stale active-quiz lock (was: `{quiz_id}`). New quizzes can now start.",
+        ephemeral=True,
+    )
+
+
 # Greenie Board command
 @tree.command(name="greenieboard", description="Show the Greenie Board for this server (last 10 quizzes per user)")
 @app_commands.guild_only()

--- a/readme.md
+++ b/readme.md
@@ -64,5 +64,6 @@ Common issues:
 
 - **Bot not responding** — Confirm the bot has the right permissions (`/checkperms`).
 - **Terms not posting** — Make sure posting is enabled (`/enableposting`).
+- **A public quiz needs to be cancelled** — A mod can run `/quizstop` (Manage Messages) to end it immediately and skip the summary. If a new quiz refuses to start because of a stuck lock, an admin can run `/quizpurge` (Manage Server) to clear it.
 
 For bugs or feature requests, [open an issue](https://github.com/joemurrell/brevitybot/issues).

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ Then run `/setup` in the channel where you want terms posted.
 | `/nextterm` | Manually post the next brevity term |
 | `/define <term>` | Look up a term's definition (with autocomplete) |
 | `/quiz [questions] [mode] [duration]` | Start a quiz (1–10 questions, public or private) |
+| `/quizstop` | Cancel the current public quiz (Manage Messages) |
+| `/quizpurge` | Force-clear a stuck active-quiz lock (Manage Server) |
 | `/greenieboard` | View the quiz leaderboard (last 10 results per user) |
 | `/setfrequency <hours>` | Set the posting interval |
 | `/enableposting` | Resume automatic posting |

--- a/tests/test_pure.py
+++ b/tests/test_pure.py
@@ -606,16 +606,25 @@ class TestModuleSurface:
             assert child.answer_idx == i
 
     def test_command_admin_gates(self):
-        """Per chunk (c): config commands must be admin-gated and guild-only."""
-        gated_admin = ["setup", "reloadterms", "setfrequency", "disableposting", "enableposting"]
+        """Per chunks (c) and (m): config and admin-recovery commands must be
+        admin-gated and guild-only. /quizstop uses manage_messages, /quizpurge
+        uses manage_guild (more restrictive — purge is a recovery hammer)."""
+        gated_manage_guild = ["setup", "reloadterms", "setfrequency", "disableposting", "enableposting", "quizpurge"]
+        gated_manage_messages = ["quizstop"]
         guild_only_no_admin = ["nextterm", "quiz", "greenieboard", "checkperms"]
         no_gate = ["define"]
-        for name in gated_admin:
+        for name in gated_manage_guild:
             cmd = brevitybot.tree.get_command(name)
             assert cmd is not None, f"missing /{name}"
             assert cmd.guild_only is True, f"/{name} should be guild_only"
             perms = cmd.default_permissions
             assert perms is not None and perms.manage_guild, f"/{name} missing manage_guild"
+        for name in gated_manage_messages:
+            cmd = brevitybot.tree.get_command(name)
+            assert cmd is not None, f"missing /{name}"
+            assert cmd.guild_only is True
+            perms = cmd.default_permissions
+            assert perms is not None and perms.manage_messages, f"/{name} missing manage_messages"
         for name in guild_only_no_admin:
             cmd = brevitybot.tree.get_command(name)
             assert cmd is not None
@@ -625,6 +634,11 @@ class TestModuleSurface:
             cmd = brevitybot.tree.get_command(name)
             assert cmd is not None
             assert cmd.guild_only is False
+
+    def test_quizstop_quizpurge_registered(self):
+        """Surface-only: /quizstop and /quizpurge exist on the tree."""
+        for name in ("quizstop", "quizpurge"):
+            assert brevitybot.tree.get_command(name) is not None, f"missing /{name}"
 
 
 # -------------------------------


### PR DESCRIPTION
Two new moderation commands for public quizzes, composing with PR #43's deadline-rejection to give moderators full operational control.

## What & why

PR #43 stopped post-deadline votes from counting. This PR adds the two missing pieces:

| Command | Permission | What it does |
|---|---|---|
| **`/quizstop`** | Manage Messages | Cancels the active public quiz immediately — cleans up Redis (meta + answer hashes + active-quiz lock), strips the buttons off each question message, posts `"Quiz cancelled by @mod"` to the channel. The pre-scheduled `close_and_summarize` task wakes up, finds meta missing, and exits silently — no orphan summary. |
| **`/quizpurge`** | Manage Server | Recovery hammer for the rare orphan-lock state (e.g. a crash between `SET NX` and meta-persist). **Refuses** if meta still exists, pointing the user to `/quizstop` instead, so it can't accidentally unlock a healthy quiz and let a second one start. |

## Design notes

- **`/quizstop`** uses the existing `_cleanup_quiz_keys(quiz_id, n, guild_id=...)` (chunk d/j/l) — meta + answer keys + active-quiz lock all dropped atomically.
- **Buttons-off**: iterates `meta["message_ids"]`, fetches each message, calls `msg.edit(view=None)`. Best-effort — a fetch failure (e.g. message deleted) doesn't block the cancel.
- **Self-recovering stale-lock path**: if `/quizstop` finds a lock with no meta (already expired), it drops the lock and reports it. No separate command needed for that subset.
- **`/quizpurge` refusal logic**: checks `EXISTS quiz:{quiz_id}:meta`. If true → refuses + points to `/quizstop`. If false → drops the lock. Prevents the dangerous "purge during healthy quiz → second concurrent quiz starts" scenario.
- **Permission split**: `/quizstop` is a frequent moderator action (Manage Messages), `/quizpurge` is a rare recovery action that overrides safety checks (Manage Server).

## Test coverage

- ✅ 89 unit tests (was 88 — added 1 surface test; admin-gate matrix test updated to cover both new commands and the `manage_messages` permission)
- ✅ 6 behavioral paths verified against a real local Redis:
  - `/quizstop` with no active quiz → ephemeral "no active quiz"
  - `/quizstop` with healthy quiz → keys cleaned, buttons stripped on all question messages, channel cancel-msg posted
  - `/quizstop` with stale lock (no meta) → lock dropped
  - `/quizpurge` with no lock → ephemeral "no lock to clear"
  - `/quizpurge` with stale lock → lock dropped
  - `/quizpurge` with healthy quiz → **refuses**, points to `/quizstop`

## Docs

- README command table gets two new rows.
- README Support section gets a "A public quiz needs to be cancelled" entry naming both commands.

## Test plan

- [ ] As a Manage-Messages user: start `/quiz mode:public questions:2 duration:5`, then `/quizstop`. Channel shows "Quiz cancelled by @mod"; buttons on both question messages are gone; no summary embed posts at the 5-min mark.
- [ ] As a regular user (no Manage Messages): `/quizstop` does NOT appear in the slash picker.
- [ ] `/quizpurge` while a healthy quiz is running: refuses with "use /quizstop instead" message; quiz continues normally.
- [ ] Stale-lock recovery: `redis-cli SET active_quiz:<guild_id> stale-id EX 3700`, then `/quizpurge` → clears it.
- [ ] Regression smoke: `/quiz`, `/define`, `/nextterm`, `/greenieboard` unchanged.

> ℹ️ As with previous deploys that added new commands or permissions, you may want to `redis-cli DEL last_command_sync` so Discord re-syncs the tree immediately. Otherwise the new commands lag in the slash picker up to an hour while the old sync cooldown elapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfLhTqJkXdZmFWQGzmmntm)_