### PR TITLE
fix: scheduled posts silently stop after a transient Redis error

### DIFF
--- a/brevitybot.py
+++ b/brevitybot.py
@@ -1777,20 +1777,30 @@ async def checkperms(interaction: discord.Interaction):
 # -------------------------------
 @tasks.loop(minutes=5)
 async def post_brevity_term():
-    all_configs = await load_config()
-    if not all_configs:
-        return
+    # The whole body is guarded by this try/except: tasks.loop silently and
+    # permanently stops a loop if an unhandled exception escapes it, and
+    # since this loop is only ever started once (in setup_hook), a single
+    # transient Redis error here would kill scheduled posting for good while
+    # the rest of the bot kept working. Catching everything means a bad tick
+    # just gets skipped and retried in 5 minutes.
+    try:
+        all_configs = await load_config()
+        if not all_configs:
+            return
 
-    # Batch all per-guild reads up-front so the per-tick Redis cost is
-    # constant in the number of guilds, not 3N (was: SISMEMBER + 2 GETs per
-    # guild). Three calls total: HGETALL channel map + SMEMBERS disabled set
-    # + 2 MGETs (freq/last_posted).
-    guild_id_strs = list(all_configs.keys())
-    disabled_guilds = await r.smembers(DISABLED_GUILDS_KEY)
-    freq_keys = [f"{FREQ_KEY_PREFIX}{gid}" for gid in guild_id_strs]
-    last_keys = [f"{LAST_POSTED_KEY_PREFIX}{gid}" for gid in guild_id_strs]
-    freq_values = await r.mget(freq_keys) if freq_keys else []
-    last_values = await r.mget(last_keys) if last_keys else []
+        # Batch all per-guild reads up-front so the per-tick Redis cost is
+        # constant in the number of guilds, not 3N (was: SISMEMBER + 2 GETs per
+        # guild). Three calls total: HGETALL channel map + SMEMBERS disabled set
+        # + 2 MGETs (freq/last_posted).
+        guild_id_strs = list(all_configs.keys())
+        disabled_guilds = await r.smembers(DISABLED_GUILDS_KEY)
+        freq_keys = [f"{FREQ_KEY_PREFIX}{gid}" for gid in guild_id_strs]
+        last_keys = [f"{LAST_POSTED_KEY_PREFIX}{gid}" for gid in guild_id_strs]
+        freq_values = await r.mget(freq_keys) if freq_keys else []
+        last_values = await r.mget(last_keys) if last_keys else []
+    except Exception as e:
+        logger.error("post_brevity_term: failed to load per-tick config, skipping this tick: %s", e)
+        return
 
     current_time = time.time()
     for i, guild_id_str in enumerate(guild_id_strs):
@@ -1847,11 +1857,29 @@ async def post_brevity_term():
 
 @tasks.loop(hours=24)
 async def refresh_terms_daily():
-    await update_brevity_terms()
+    # Same rationale as post_brevity_term: an unhandled exception here would
+    # permanently stop this loop (tasks.loop doesn't auto-restart), so a
+    # transient Redis/network failure must not escape the body.
+    try:
+        await update_brevity_terms()
+    except Exception as e:
+        logger.error("refresh_terms_daily: failed to refresh terms, will retry next cycle: %s", e)
 
 @tasks.loop(hours=1)
 async def log_bot_stats():
     logger.info("BrevityBot Statistics: Servers: %d", len(client.guilds))
+
+    # Self-healing backstop: tasks.loop permanently stops a loop on an
+    # unhandled exception and nothing else restarts it. The loops above now
+    # guard their own bodies, but if one still dies unexpectedly, restart it
+    # here rather than silently losing scheduled posting/term refresh until
+    # the next deploy.
+    if not post_brevity_term.is_running():
+        logger.warning("post_brevity_term loop was not running; restarting it.")
+        post_brevity_term.start()
+    if not refresh_terms_daily.is_running():
+        logger.warning("refresh_terms_daily loop was not running; restarting it.")
+        refresh_terms_daily.start()
 
 # -------------------------------
 # BOT READY EVENT


### PR DESCRIPTION
## Summary

Root cause of scheduled posts silently stopping: `post_brevity_term`'s per-tick setup (`load_config()`, `SMEMBERS`, two `MGET`s) ran **outside** the per-guild `try/except`. `discord.ext.tasks.Loop` permanently stops a loop the moment an unhandled exception escapes its body, and since `post_brevity_term` is only ever `.start()`ed once (in `setup_hook`), a single transient Redis error (a connection blip — the exact scenario the existing `health_check_interval=30` tuning targets) would kill scheduled posting for good, while everything else (slash commands, health check) kept working normally. That matches the report: channel correctly configured via `/setup`, but the scheduled term never sends again after some point.

`refresh_terms_daily` has the identical structural vulnerability (`update_brevity_terms()` does unguarded Redis reads/writes), so no term refresh would happen either after a similar blip.

- Wrap `post_brevity_term`'s per-tick setup reads in `try/except`, logging and skipping (retrying next tick) instead of letting the exception kill the loop.
- Wrap `refresh_terms_daily`'s body the same way.
- Add a self-healing check in the hourly `log_bot_stats` loop that restarts `post_brevity_term`/`refresh_terms_daily` if either is found not running, as a backstop in case something still slips past the above.

## Test plan

- [x] `pytest tests/` — 89 passed
- [x] `python -c "import ast; ast.parse(open('brevitybot.py').read())"` — syntax OK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPrFny3m6V1PFmmAaicT9F)_